### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Piccolo_Projects/GenerativeForest/README.md
+++ b/Piccolo_Projects/GenerativeForest/README.md
@@ -5,13 +5,13 @@ A Piccolo Project
 Piccolo is a pocket-sized stand-alone CNC platform.  For more info please see [www.piccolo.cc](http://www.piccolo.cc)
 
 
-####About: 
+#### About: 
 Piccolo draws a generative forest across a table top.
 
 Piccolo draws generative plants and trees using a light sensor as it's input. When Piccolo is placed under a bight light, taller and more bushy tree is generated and drawn while lower light levels or shadows result in small shrubs and grasses. 
 
 
-####You Will Need:
+#### You Will Need:
 
 - 1 x Piccolo
 - 1 x LDR (Light dependent resistor)
@@ -20,7 +20,7 @@ Piccolo draws generative plants and trees using a light sensor as it's input. Wh
 - PiccoloLib (tested with v0.8)
 - GenerativeForest Arduino sketch
 
-####Assembley: 
+#### Assembley: 
 
 Wire your LDR with one leg connected to the A2 input on the side of your piccolo and the other connected to GND, now take your resistor and connect one end to VCC and the other also to A2.
 
@@ -30,7 +30,7 @@ The LDR can be placed at other points on Piccolo for example the Z-Axis by solde
 
 Make sure PicccoloLib is installed correctly and upload the GenerativeForest Sketch to piccolo. 
 
-####Usage: 
+#### Usage: 
 
 - Add a drawing implement to Piccolo and set the drawing height using the thumb wheel. 
 - Place Piccolo under the darkest point of light on the surface and hold down button two for two seconds (the button next to the usb plug) this calibrates you light sensor.

--- a/Piccolo_Projects/Portrait/README.md
+++ b/Piccolo_Projects/Portrait/README.md
@@ -5,5 +5,5 @@ A Piccolo Project
 Piccolo is a pocket-sized stand-alone CNC platform.  For more info please see [www.piccolo.cc](http://www.piccolo.cc)
 
 
-####About: 
+#### About: 
 Portrait is a work in progress. Using the face online API piccolo draws portraits of peoples faces. 

--- a/Piccolo_Software/Controllo/README.md
+++ b/Piccolo_Software/Controllo/README.md
@@ -6,17 +6,17 @@ Controllo is a standalone program that runs on your, pc , mac or linux machine. 
 Your Piccolo will need to have the usbTether firmware installed and be attached to your computer in order to communicate with Controllo. The usbTether program can be found in [PiccoloLib](https://github.com/DiatomStudio/Piccolo/tree/master/PiccoloLib) under examples.
  
 ![](http://farm4.staticflickr.com/3682/11873676554_9e2fb8b5b3_o_d.png)
-####installing
+#### installing
 - Download Controllo_current.zip
 - Unzip and run the appropriate application for your system.
 
-####how to use
+#### how to use
 - Load your own svg or select a generative pattern using the buttons on the left. 
 - Lower your piccolo's drawing implement to the paper using either the thumb where on the side of the Piccolo or the UP_ DOWN_ buttons in Controllo.
 - Press the STARRT button or button_1 on your Piccolo to start drawing. 
 
 
-####hacking
+#### hacking
 Controllo is written using the Processing programming language. If you would like to make your own changes you will need.
 
 - Processing: <http://processing.org/>
@@ -26,7 +26,7 @@ the following processing libraries
 - controlP5: <http://www.sojamo.de/libraries/controlP5/>
 - Geomerative: <http://www.ricardmarxer.com/geomerative/>
 
-####notes
+#### notes
 To correctly draw imported SVG drawings, SVG's should be exported with all lines expanded and no compound shapes. 
 
 The sag size should be less than 300 x 300 px. 

--- a/Piccolo_Software/PiccoloLib/PiccoloLib/README.md
+++ b/Piccolo_Software/PiccoloLib/PiccoloLib/README.md
@@ -1,29 +1,29 @@
-##PiccoloLib v0.81  
+## PiccoloLib v0.81  
 *Arduino library for controlling Piccolo, the tiny CNC-bot.*  
 
 Piccolo.cc  
 Created by Diatom Studio, October 10, 2013.  
 Released into the public domain.  
 
-##Changes:
+## Changes:
 
-###0.82  
+### 0.82  
 - Fixing bugs in examples.
 - Removed incompatible examples. 
 
-###0.81  
+### 0.81  
 -  Minor restructuring of comments. 
 -  Added bezier(y,z) function
 -  Commented out unused Piccolo Axis functions.s
 
-###0.8  
+### 0.8  
 -  Major restructuring of code. 
 -  Added Axis objects to store and calculate Axis positions. 
 
-###0.21  
+### 0.21  
 -  Reverted BeginShape and EndShape back to BeginDraw and EndDraw to bring them in line with processing.org
 -  Changed received coordinates from human readable chars to signed 32 bit ints backed into 4 bytes. This make our ranges larger, supports negative numbers and we send less data. 
 
-###0.2  
+### 0.2  
 -  Start of change tracking.
 

--- a/Piccolo_Software/PiccoloLib/README.md
+++ b/Piccolo_Software/PiccoloLib/README.md
@@ -1,4 +1,4 @@
-#PiccoloLib#
+# PiccoloLib #
 
 PiccoloLib is a library for [Arduino](http://www.arduino.cc) that makes it simple to program a Piccolo.
 
@@ -13,7 +13,7 @@ For an overview of PiccoloLib basics, take a look at [Getting Started](../../../
 
 ---
 
-##Installation##
+## Installation ##
 
 1. Download PiccoloLib_current.zip
 2. Open the zip in Arduino by: Sketch > Import Library > Add Library
@@ -23,15 +23,15 @@ If you are not sure where your libraries folder is, have a look at the Arduino l
 
 ---
 
-##Reference##
+## Reference ##
 
 Piccolo's output is intended to be used in mm, however you can scale the output to any arbitrary units using *calibrate()*.
 
 
-###PiccoloLib Class###
+### PiccoloLib Class ###
 
 ---
-####Setup, Configuration & Motion####
+#### Setup, Configuration & Motion ####
 
 `void setup()`  
 Sets up piccolo using the default pin assignments for the servos:  
@@ -77,7 +77,7 @@ This also affects curvature when using *ellipse()*, *arc()*, or *bezier()* - a s
 Disables servo motion, for debugging purposes.
 
 ---
-####Piccolo Inputs####
+#### Piccolo Inputs ####
 
 `float readThumbwheel()`  
 Returns a value from 0 to 1023 based on the position of the thumbwheel.
@@ -89,7 +89,7 @@ Returns true if button one is pressed.
 Returns true if button two is pressed.
 
 ---
-####Mechanical Control####
+#### Mechanical Control ####
 
 `void moveX(float x)`  
 `void moveY(float y)`  
@@ -111,7 +111,7 @@ Will move piccolo in each axis based on the thumbwheel position, between the min
 Set or retrieve the pen-down position.
 
 ---
-####Making Shapes####
+#### Making Shapes ####
 
 In general all drawing commands follow the same format as Processing drawing commands, for more info on these please visit: http://processing.org/reference/
 
@@ -136,7 +136,7 @@ Moves piccolo to (x,y,z) using the step size and speed to control the motion.
 `float bezierTangent(float a, float b, float c, float d, float t)`  
 
 ---
-####Serial Communication####
+#### Serial Communication ####
 
 `void serialSetup()`  
 Opens a serial port at 115200 baud. ready for Piccolo instructions from Controllo or another host device. This is only needed if Piccolo is controlled remotely. 
@@ -150,13 +150,13 @@ This is also useful for retrieving coordinates from Piccolo to debug your toolpa
 
 
 ---
-###PiccoloAxis class###
+### PiccoloAxis class ###
 
 Each servo is controlled as a PiccoloAxis object.  
 *uS = pulse width in microseconds of signal sent to the servo.*
 
 ---
-####Variable Heirarchy####
+#### Variable Heirarchy ####
 
 1. `uScenter` - Defines the center position of the servo, based on where we want piccolo think the center is.  Normally this would be mid-way between the minimum and maximum rotation of the servo.  Default is 1551uS.  
 `bedSize` - We define what we want the bed size to be.  The default is 50mm, which is a conservative size that should fit within the range of most DS929-MG servos.  
@@ -177,7 +177,7 @@ Each servo is controlled as a PiccoloAxis object.
 `uSdeg  = ((target*uSmm)/actual) * (PI/360)*gearSize`
 
 ---
-####Setup, Configuration & Motion####
+#### Setup, Configuration & Motion ####
 
 `void setup(int _pin)`  
 `void setup(int _pin, int _uScenter, float _bedSize)`  
@@ -196,7 +196,7 @@ Each servo is controlled as a PiccoloAxis object.
 `void move(float _pos)`  
 
 ---
-####Helper Functions####
+#### Helper Functions ####
 
 `int getPin()`  
 `int getuScenter()`  

--- a/Piccolo_Software/PiccoloP5/README.md
+++ b/Piccolo_Software/PiccoloP5/README.md
@@ -1,18 +1,18 @@
-##PiccoloP5  
+## PiccoloP5  
 *PiccoloP5 is a Processing library for controlling Piccolo, the Tiny CNC-bot, from your processing sketch.*
 
 Piccolo.cc  
 Created by Diatom Studio, 16 October, 2014.  
 Released into the public domain.  
 
-##Installation  
+## Installation  
 
 To Install the PiccoloP5 library:  
 1. Unzip /distribution/PiccoloP5-1/download/PiccoloP5.zip to your processing libraries directory.  
 2. Restart Processing.  
 3. Select  Sketch > Import Library > Piccolo P5  
 
-##Hello Piccolo Example
+## Hello Piccolo Example
 
 ```Processing
 import piccoloP5.*;

--- a/Piccolo_Software/README.md
+++ b/Piccolo_Software/README.md
@@ -9,12 +9,12 @@ Controllo is a standalone program that runs on your, pc , mac or linux machine. 
 ----------------
 PiccoloLib is a Arduino library for controlling Piccolo using Arduino and Processing like drawing calls. 
 
-#####usbTether src
+##### usbTether src
 PiccoloLib includes an example program (sketch) 'usbTether'. This sketch needs to be uploaded to your Piccolo in order to use Controllo or PiccoloP5 with your Piccolo. 
 
 ### PiccoloP5
 ----------------
 PiccoloP5 is a Processing library for controlling your Piccolo from your computer in real time. Processing drawing commands can be sent to your Piccolo for drawing. 
 
-#####Controllo src
+##### Controllo src
 Controllo is included as example in the PiccoloP5 library. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Piccolo, the tiny cnc bot#
+# Piccolo, the tiny cnc bot #
 
 A pocket sized open source CNC-bot.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
